### PR TITLE
コメントに画像添付機能を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# CLAUDE.md - エージェント支援ガイド
+
+## コマンド
+- JS ビルド: `yarn build`
+- CSS ビルド: `yarn build:css`
+- サーバー起動: `bin/rails server`
+- 開発環境: `bin/dev` (foreman経由で全サービス起動)
+- テスト実行: `bin/rspec [ファイルパス:行番号]`
+- 単一テスト: `bin/rspec spec/path/to_spec.rb:行番号`
+- リント: `bin/rubocop [--auto-correct]`
+- セキュリティスキャン: `bin/brakeman`
+
+## コードスタイル・規約
+- Ruby: Rails御膳スタイル (rubocop-rails プリセット)
+- フロントエンド: Tailwind CSS でスタイリング
+- JS: Stimulus でインタラクション、Turbo でページ更新
+- モデル: ActiveRecord バリデーション使用、コールバックは控えめに
+- コントローラー: 薄く保ち、Strong Parameters を使用
+- ビュー: 再利用可能なコンポーネントにはパーシャルを使用
+- エラー処理: Rails の規約に従い、コントローラーでrescue
+- 命名規則: Rubyはsnake_case、JSはcamelCase
+- 画像: Cloudinary を使用 (cloudinary.yml参照)
+
+## サービス
+デプロイ先: Back4app、Neon (PostgreSQL)、Upstash、Cloudinary

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -13,6 +13,6 @@ class CommentsController < ApplicationController
   private
 
   def comment_params
-    params.require(:comment).permit(:content)
+    params.require(:comment).permit(:content, :image)
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,4 +2,6 @@ class Comment < ApplicationRecord
   belongs_to :board
 
   validates :content, presence: true
+
+  mount_uploader :image, ImageUploader
 end

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -23,7 +23,12 @@
       <% if @board.comments.any? %>
         <div class="space-y-4 mb-6">
           <% @board.comments.order(created_at: :desc).each do |comment| %>
-            <div class="border-b pb-2">
+            <div class="border-b pb-4">
+              <% if comment.image.present? %>
+                <div class="mb-2">
+                  <%= image_tag comment.image.url, class: "max-w-xs rounded-lg shadow-sm" %>
+                </div>
+              <% end %>
               <p class="text-gray-700"><%= comment.content %></p>
               <p class="text-xs text-gray-500"><%= comment.created_at.strftime('%Y/%m/%d %H:%M') %></p>
             </div>
@@ -36,9 +41,13 @@
       <!-- コメントフォーム -->
       <div class="mt-6">
         <h3 class="text-lg font-semibold mb-2">コメントを投稿</h3>
-        <%= form_with(model: [@board, @board.comments.build], local: true, class: "space-y-4") do |form| %>
+        <%= form_with(model: [@board, @board.comments.build], local: true, class: "space-y-4", html: { multipart: true }) do |form| %>
           <div>
             <%= form.text_area :content, rows: 3, class: "w-full border rounded-lg p-2", placeholder: "コメントを入力してください" %>
+          </div>
+          <div class="flex items-center space-x-2">
+            <%= form.label :image, "画像", class: "text-gray-700" %>
+            <%= form.file_field :image, class: "text-sm file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100" %>
           </div>
           <div>
             <%= form.submit "投稿する", class: "bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700" %>

--- a/db/migrate/20250309041905_add_image_to_comments.rb
+++ b/db/migrate/20250309041905_add_image_to_comments.rb
@@ -1,0 +1,5 @@
+class AddImageToComments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :comments, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_09_040540) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_09_041905) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_09_040540) do
     t.bigint "board_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "image"
     t.index ["board_id"], name: "index_comments_on_board_id"
   end
 


### PR DESCRIPTION
## Summary
- Commentモデルに画像フィールド(image)を追加
- CarrierWaveのImageUploaderを使用して画像アップロード機能を実装
- コメントフォームに画像アップロード用の入力欄を追加
- コメント一覧表示で画像が表示されるよう修正

## Test plan
- コメント投稿時に画像が添付できることを確認
- アップロードした画像が正しく表示されることを確認
- 画像なしでもコメントが投稿できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)